### PR TITLE
FIX: Can not init Operations with value

### DIFF
--- a/Sources/Swot/Operations.swift
+++ b/Sources/Swot/Operations.swift
@@ -17,6 +17,10 @@ public struct Keep: ChangesetOperation {
     /// Kept characters
     public let value: Int
     public var length: Int { return value }
+
+    public init(value: Int) {
+        self.value = value
+    }
 }
 
 
@@ -25,6 +29,10 @@ public struct Add: ChangesetOperation {
     /// Added characters
     public let value: String
     public var length: Int { return value.count }
+
+    public init(value: String) {
+        self.value = value
+    }
 }
 
 
@@ -33,4 +41,8 @@ public struct Remove: ChangesetOperation {
     /// Removed characters
     public let value: Int
     public var length: Int { return value }
+
+    public init(value: Int) {
+        self.value = value
+    }
 }


### PR DESCRIPTION
`init` function is not defined as public, so it cannot be initialized by the procedure described in the README.md.

![image](https://user-images.githubusercontent.com/1782746/125490460-8425a0d2-00c7-47ea-ac54-a1dd370f0345.png)

To solve this problem, I have added `init(value: )` to all Operations.