### PR TITLE
Throw error instead of `fatalError`

### DIFF
--- a/Sources/Swot/Changeset.swift
+++ b/Sources/Swot/Changeset.swift
@@ -18,6 +18,8 @@ public struct Changeset {
         case uncombinableChangesets
         /// Unknown combination of Changeset Operation
         case unknownOperationCombination
+        /// Trying to encode unknown operation
+        case canNotEncodeUnknownOperation
     }
     
     /**

--- a/Sources/Swot/Changeset.swift
+++ b/Sources/Swot/Changeset.swift
@@ -201,7 +201,7 @@ extension Changeset {
                     right.removeFirst()
                 }
             default:
-                fatalError("Unknown operation combination when trying to compose two changesets")
+                throw ChangesetError.unknownOperationCombination
             }
             
             if left.isEmpty && right.isEmpty { finished = true }
@@ -287,7 +287,7 @@ extension Changeset {
                     right.attemptToRemoveFirst()
                 }
             default:
-                fatalError("Unknown operation combination when trying to harmonize two changesets")
+                throw ChangesetError.unknownOperationCombination
             }
             
             if left.isEmpty && right.isEmpty { finished = true }

--- a/Sources/Swot/Changeset.swift
+++ b/Sources/Swot/Changeset.swift
@@ -347,7 +347,7 @@ extension Changeset: Codable {
                 try operationContainer.encode(OperationType.remove, forKey: .type)
                 try operationContainer.encode(op.value, forKey: .value)
             default:
-                fatalError("Trying to encode unknown operation")
+                throw ChangesetError.canNotEncodeUnknownOperation
             }
         }
     }

--- a/Sources/Swot/Changeset.swift
+++ b/Sources/Swot/Changeset.swift
@@ -16,6 +16,8 @@ public struct Changeset {
         case uncomposableChangesets
         /// Changesets can't be combined.
         case uncombinableChangesets
+        /// Unknown combination of Changeset Operation
+        case unknownOperationCombination
     }
     
     /**


### PR DESCRIPTION
I have modified the code to throws errors instead of using `fatalError`. Utilizing `fatalError` leads to application crashes with no possibility of recovery.